### PR TITLE
build(webpack): rename devServer property contentBase for static

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 module.exports = merge(config, {
     devServer: {
-        contentBase: path.resolve(__dirname, 'demo'),
+        static: path.resolve(__dirname, 'demo'),
     },
     devtool: 'inline-source-map',
     entry: path.resolve(__dirname, 'demo/index.js'),


### PR DESCRIPTION
# Description

#### Please describe the reason related to the changes:

Webpack removed ```devServer``` property ```contentBase``` in favor of ```static```.

# Type

#### Please select the type related to the changes:

- [ ] bugfix
- [x] build
- [ ] continuous delivery (CD)
- [ ] continuous integration (CI)
- [ ] documentation
- [ ] feature
- [ ] formatting
- [ ] refactoring
- [ ] styling
- [ ] other (please describe below):

# Breaking Change

#### Does your changes introduce a breaking change?

- [x] no
- [ ] yes

# Behavior

#### Please describe the current behavior:

Scripts using the Webpack dev config e.g. ```npm run start``` won't work without the new property ```static```.

# Changes

#### Please describe the new behavior:

Scripts using the Webpack dev config work correctly.

# Information (issue, links, logs, etc.)

#### Please list any other useful information:

[webpack-dev-server 4.0.0](https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md#400-beta0-2020-11-27)

# Checklist

#### Please make sure this pull request follow the requirements

- [x] commit guidelines [@commitlint/config-conventional](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] **100%** code coverage
- [x] tests passing
