### PR TITLE
chore(esmodules): enable ES modules in NodeJS

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from 'react-dom';
-import App from '../src';
+import App from '../src/index.js';
 import './styles.scss';
 
 render(<App />, document.getElementById('root'));

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     moduleDirectories: ['node_modules', 'src'],
     setupFiles: ['./jest.setup.js'],
     setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "React boilerplate",
     "main": "dist/index.js",
     "module": "dist/index.js",
+    "type": "module",
     "files": [
         "dist"
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,9 @@
-const path = require('path');
+import path from 'path';
+import { fileURLToPath } from 'url';
 
-module.exports = {
+export const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default {
     module: {
         rules: [
             {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,8 +1,8 @@
-const config = require('./webpack.config.js');
-const { merge } = require('webpack-merge');
-const path = require('path');
+import path from 'path';
+import { merge } from 'webpack-merge';
+import config, { __dirname } from './webpack.config.js';
 
-module.exports = merge(config, {
+export default merge(config, {
     devServer: {
         static: path.resolve(__dirname, 'demo'),
     },

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,8 +1,8 @@
-const config = require('./webpack.config.js');
-const { merge } = require('webpack-merge');
-const path = require('path');
+import path from 'path';
+import { merge } from 'webpack-merge';
+import config, { __dirname } from './webpack.config.js';
 
-module.exports = merge(config, {
+export default merge(config, {
     devtool: 'source-map',
     entry: path.resolve(__dirname, 'src/index.js'),
     externals: {


### PR DESCRIPTION
# Description

#### Please describe the reason related to the changes:

Add new field ```type``` with value ```module``` to file ```package.json``` to enable ES modules in a NodeJS environment.

# Type

#### Please select the type related to the changes:

- [ ] bugfix
- [ ] build
- [ ] continuous delivery (CD)
- [ ] continuous integration (CI)
- [ ] documentation
- [x] feature
- [ ] formatting
- [ ] refactoring
- [ ] styling
- [ ] other (please describe below):

# Breaking Change

#### Does your changes introduce a breaking change?

- [x] no
- [ ] yes

# Behavior

#### Please describe the current behavior:

Using ES modules in a NodeJS environment is not possible.

# Changes

#### Please describe the new behavior:

Using ES modules in a NodeJS environment is now possible.

# Information (issue, links, logs, etc.)

#### Please list any other useful information:

[NodeJS support ES modules](https://nodejs.medium.com/announcing-core-node-js-support-for-ecmascript-modules-c5d6dc29b663)

# Checklist

#### Please make sure this pull request follow the requirements

- [x] commit guidelines [@commitlint/config-conventional](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] **100%** code coverage
- [x] tests passing
