### PR TITLE
chore(babel): update babel-eslint to @babel/eslint-parser

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
         "node": true
     },
     "noInlineConfig": false,
-    "parser": "babel-eslint",
+    "parser": "@babel/eslint-parser",
     "parserOptions": {
         "ecmaVersion": 6,
         "sourceType": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "devDependencies": {
                 "@babel/cli": "7.16.8",
                 "@babel/core": "7.16.7",
+                "@babel/eslint-parser": "^7.16.5",
                 "@babel/plugin-transform-runtime": "7.16.8",
                 "@babel/preset-env": "7.16.8",
                 "@babel/preset-react": "7.16.7",
@@ -22,7 +23,6 @@
                 "@testing-library/react": "12.1.2",
                 "@testing-library/react-hooks": "7.0.2",
                 "@testing-library/user-event": "13.5.0",
-                "babel-eslint": "10.1.0",
                 "babel-loader": "8.2.3",
                 "babel-plugin-jsx-remove-data-test-id": "3.0.0",
                 "commitizen": "4.2.4",
@@ -140,6 +140,33 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@babel/eslint-parser": {
+            "version": "7.16.5",
+            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.5.tgz",
+            "integrity": "sha512-mUqYa46lgWqHKQ33Q6LNCGp/wPR3eqOYTUixHFsfrSQqRxH0+WOzca75iEjFr5RDGH1dDz622LaHhLOzOuQRUA==",
+            "dev": true,
+            "dependencies": {
+                "eslint-scope": "^5.1.1",
+                "eslint-visitor-keys": "^2.1.0",
+                "semver": "^6.3.0"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": ">=7.11.0",
+                "eslint": "^7.5.0 || ^8.0.0"
+            }
+        },
+        "node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/@babel/generator": {
@@ -5447,27 +5474,6 @@
             "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
             "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
             "dev": true
-        },
-        "node_modules/babel-eslint": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-            "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-            "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
-            "dev": true,
-            "dependencies": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.7.0",
-                "@babel/traverse": "^7.7.0",
-                "@babel/types": "^7.7.0",
-                "eslint-visitor-keys": "^1.0.0",
-                "resolve": "^1.12.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "peerDependencies": {
-                "eslint": ">= 4.12.1"
-            }
         },
         "node_modules/babel-jest": {
             "version": "27.4.6",
@@ -19892,6 +19898,25 @@
                 "source-map": "^0.5.0"
             }
         },
+        "@babel/eslint-parser": {
+            "version": "7.16.5",
+            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.5.tgz",
+            "integrity": "sha512-mUqYa46lgWqHKQ33Q6LNCGp/wPR3eqOYTUixHFsfrSQqRxH0+WOzca75iEjFr5RDGH1dDz622LaHhLOzOuQRUA==",
+            "dev": true,
+            "requires": {
+                "eslint-scope": "^5.1.1",
+                "eslint-visitor-keys": "^2.1.0",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+                    "dev": true
+                }
+            }
+        },
         "@babel/generator": {
             "version": "7.16.8",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
@@ -23903,20 +23928,6 @@
             "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
             "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
             "dev": true
-        },
-        "babel-eslint": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-            "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.7.0",
-                "@babel/traverse": "^7.7.0",
-                "@babel/types": "^7.7.0",
-                "eslint-visitor-keys": "^1.0.0",
-                "resolve": "^1.12.0"
-            }
         },
         "babel-jest": {
             "version": "27.4.6",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "devDependencies": {
         "@babel/cli": "7.16.8",
         "@babel/core": "7.16.7",
+        "@babel/eslint-parser": "^7.16.5",
         "@babel/plugin-transform-runtime": "7.16.8",
         "@babel/preset-env": "7.16.8",
         "@babel/preset-react": "7.16.7",
@@ -55,7 +56,6 @@
         "@testing-library/react": "12.1.2",
         "@testing-library/react-hooks": "7.0.2",
         "@testing-library/user-event": "13.5.0",
-        "babel-eslint": "10.1.0",
         "babel-loader": "8.2.3",
         "babel-plugin-jsx-remove-data-test-id": "3.0.0",
         "commitizen": "4.2.4",


### PR DESCRIPTION
# Description

#### Please describe the reason related to the changes:

Babel-eslint is now deprecated.

# Type

#### Please select the type related to the changes:

- [ ] bugfix
- [x] build
- [ ] continuous delivery (CD)
- [ ] continuous integration (CI)
- [ ] documentation
- [ ] feature
- [ ] formatting
- [ ] refactoring
- [ ] styling
- [ ] other (please describe below):

# Breaking Change

#### Does your changes introduce a breaking change?

- [x] no
- [ ] yes

# Behavior

#### Please describe the current behavior:

Eslint won't parse.

# Changes

#### Please describe the new behavior:

Eslint parse correctly.

# Information (issue, links, logs, etc.)

#### Please list any other useful information:

# Checklist

#### Please make sure this pull request follow the requirements

- [x] commit guidelines [@commitlint/config-conventional](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] **100%** code coverage
- [x] tests passing
